### PR TITLE
fix: let multimeter split analog signals for every cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * @drodarie made their first contribution in https://github.com/dbbs-lab/bsb-nest/pull/7
 
 **Full Changelog**: https://github.com/dbbs-lab/bsb-nest/compare/v4.0.0...v4.1.0
+
 [v4.2.0]: https://github.com/dbbs-lab/bsb-nest/compare/v4.1.0...v4.2.0
 [v4.2.1]: https://github.com/dbbs-lab/bsb-nest/compare/v4.2.0...v4.2.1
 [v4.3.0]: https://github.com/dbbs-lab/bsb-nest/compare/v4.2.1...v4.3.0

--- a/bsb_nest/device.py
+++ b/bsb_nest/device.py
@@ -1,10 +1,12 @@
+import typing
 import warnings
 
 import nest
 from bsb import DeviceModel, SimulationData, Targetting, config, refs, types
 
-from .adapter import NestAdapter
-from .simulation import NestSimulation
+if typing.TYPE_CHECKING:
+    from .adapter import NestAdapter
+    from .simulation import NestSimulation
 
 
 @config.node

--- a/bsb_nest/device.py
+++ b/bsb_nest/device.py
@@ -1,7 +1,10 @@
 import warnings
 
 import nest
-from bsb import DeviceModel, Targetting, config, refs, types
+from bsb import DeviceModel, SimulationData, Targetting, config, refs, types
+
+from .adapter import NestAdapter
+from .simulation import NestSimulation
 
 
 @config.node
@@ -24,18 +27,56 @@ class NestDevice(DeviceModel):
     receptor_type = config.attr(type=int, required=False, default=0)
     """Integer ID of the postsynaptic target receptor"""
 
-    def get_target_nodes(self, adapter, simulation, simdata):
+    def get_dict_targets(
+        self,
+        adapter: "NestAdapter",
+        simulation: "NestSimulation",
+        simdata: "SimulationData",
+    ) -> dict:
+        """
+        Get a dictionary from a target group to its NEST Collection
+        for each target group of the device.
+
+        :param bsb_nest.NestAdapter adapter:
+        :param bsb_nest.NestSimulation simulation: Nest simulation instance
+        :param bsb.SimulationData simdata: Simulation data instance
+        :return: dictionary of device target group to NEST Collection
+        :rtype: dict
+        """
         if isinstance(self.targetting, Targetting):
-            node_collector = self.targetting.get_targets(
-                adapter, simulation, simdata
-            ).values()
+            node_collector = self.targetting.get_targets(adapter, simulation, simdata)
         else:
-            node_collector = (
-                simdata.populations[model][targets]
+            node_collector = {
+                model: simdata.populations[model][targets]
                 for model, targets in simdata.populations.items()
                 if not self.targetting.cell_models or model in self.targetting.cell_models
-            )
-        return sum(node_collector, start=nest.NodeCollection())
+            }
+        return node_collector
+
+    @staticmethod
+    def _flatten_nodes_ids(dict_targets):
+        return sum(dict_targets.values(), start=nest.NodeCollection())
+
+    @staticmethod
+    def _invert_targets_dict(dict_targets):
+        return {elem: k.name for k, v in dict_targets.items() for elem in v.tolist()}
+
+    def get_target_nodes(
+        self,
+        adapter: "NestAdapter",
+        simulation: "NestSimulation",
+        simdata: "SimulationData",
+    ):
+        """
+        Get the NEST Collection of the targets of the device.
+
+        :param bsb_nest.NestAdapter adapter:
+        :param bsb_nest.NestSimulation simulation: Nest simulation instance
+        :param bsb.SimulationData simdata: Simulation data instance
+        :return: Flattened NEST collection with all the targets of the device
+        """
+        targets_dict = self.get_dict_targets(adapter, simulation, simdata)
+        return self._flatten_nodes_ids(targets_dict)
 
     def connect_to_nodes(self, device, nodes):
         if len(nodes) == 0:
@@ -75,5 +116,5 @@ class ExtNestDevice(NestDevice, classmap_entry="external"):
         simdata.devices[self] = device = nest.Create(
             self.nest_model, params=self.constants
         )
-        nodes = self.get_target_nodes(adapter, simdata)
+        nodes = self.get_target_nodes(adapter, simulation, simdata)
         self.connect_to_nodes(device, nodes)

--- a/bsb_nest/devices/poisson_generator.py
+++ b/bsb_nest/devices/poisson_generator.py
@@ -35,6 +35,7 @@ class PoissonGenerator(NestDevice, classmap_entry="poisson_generator"):
                     senders=sr.events["senders"],
                     t_stop=simulation.duration,
                     device=self.name,
+                    pop_size=len(nodes),
                 )
             )
 

--- a/bsb_nest/devices/sinusoidal_poisson_generator.py
+++ b/bsb_nest/devices/sinusoidal_poisson_generator.py
@@ -1,5 +1,5 @@
 import nest
-from bsb import config
+from bsb import ConfigurationError, config
 from neo import SpikeTrain
 
 from ..device import NestDevice
@@ -56,6 +56,7 @@ class SinusoidalPoissonGenerator(
                     senders=sr.events["senders"],
                     t_stop=simulation.duration,
                     device=self.name,
+                    pop_size=len(nodes),
                 )
             )
 

--- a/tests/test_nest.py
+++ b/tests/test_nest.py
@@ -245,7 +245,7 @@ class TestNest(
         membrane_potentials = results.analogsignals[0]
         # last time point is not recorded because of recorder delay.
         self.assertTrue(len(membrane_potentials) == duration / resolution - 1)
-        self.assertTrue(np.unique(membrane_potentials.annotations["senders"]) == 1)
+        self.assertTrue(membrane_potentials.annotations["cell_id"] == 1)
         defaults = nest.GetDefaults("iaf_cond_alpha")
         # since current injected is positive, the V_m should be clamped between default
         # initial V_m = -70mV and spike threshold V_th = -55 mV


### PR DESCRIPTION
Until now all analog signals recorded for a property were stored in the same array, maybe it is more straightforward to split the analog signal for every target is recorded.