### PR TITLE
fix: senders store in array_annotations dictionary

### DIFF
--- a/.github/devops/install-nest.sh
+++ b/.github/devops/install-nest.sh
@@ -3,6 +3,7 @@ cd $GITHUB_WORKSPACE/_nest_repo
 git checkout tags/v$1
 mkdir build
 cd build
+sudo apt install libgsl-dev -y
 pip install cython cmake
 mkdir -p $2
 cmake .. \

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,4 +11,4 @@ jobs:
     - uses: psf/black@stable
       with:
         options: "--check --verbose"
-        version: "24.1.1"
+        version: "25.1.0"

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -17,4 +17,4 @@ jobs:
           sudo apt install openmpi-bin libopenmpi-dev
       # Install dependencies for proper 1st/2nd/3rd party import sorting
       - run: pip install -e .[parallel]
-      - uses: isort/isort-action@v1.1.0
+      - uses: isort/isort-action@master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,11 @@ default_install_hook_types:
   - commit-msg
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.1
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.0
     hooks:
       - id: isort
         name: isort (python)

--- a/bsb_nest/adapter.py
+++ b/bsb_nest/adapter.py
@@ -32,7 +32,7 @@ class NestResult(SimulationResult):
             segment.spiketrains.append(
                 SpikeTrain(
                     events["times"],
-                    waveforms=events["senders"],
+                    array_annotations={"senders": events["senders"]},
                     t_stop=nest.biological_time,
                     units="ms",
                     **annotations,

--- a/bsb_nest/adapter.py
+++ b/bsb_nest/adapter.py
@@ -3,7 +3,6 @@ import typing
 
 import nest
 from bsb import (
-    MPI,
     AdapterError,
     AdapterProgress,
     SimulationData,
@@ -43,18 +42,18 @@ class NestResult(SimulationResult):
 
 
 class NestAdapter(SimulatorAdapter):
-    def __init__(self):
-        self.simdata = dict()
+    def __init__(self, comm=None):
+        super().__init__(comm=comm)
         self.loaded_modules = set()
 
-    def simulate(self, simulation):
+    def simulate(self, *simulations, post_prepare=None):
         try:
             self.reset_kernel()
-            return super().simulate(simulation)
+            return super().simulate(*simulations, post_prepare=post_prepare)
         finally:
             self.reset_kernel()
 
-    def prepare(self, simulation, comm=None):
+    def prepare(self, simulation):
         self.simdata[simulation] = SimulationData(
             simulation, result=NestResult(simulation)
         )
@@ -79,7 +78,7 @@ class NestAdapter(SimulatorAdapter):
         # to appropriately warn them when they load them twice.
         self.loaded_modules = set()
 
-    def run(self, *simulations, comm=None):
+    def run(self, *simulations):
         unprepared = [sim for sim in simulations if sim not in self.simdata]
         if unprepared:
             raise AdapterError(f"Unprepared for simulations: {', '.join(unprepared)}")
@@ -134,7 +133,7 @@ class NestAdapter(SimulatorAdapter):
         """
         simdata = self.simdata[simulation]
         iter = simulation.connection_models.values()
-        if MPI.get_rank() == 0:
+        if self.comm.get_rank() == 0:
             iter = tqdm(iter, desc="", file=sys.stdout)
         for connection_model in iter:
             try:
@@ -156,7 +155,7 @@ class NestAdapter(SimulatorAdapter):
             try:
                 simdata.connections[connection_model] = (
                     connection_model.create_connections(
-                        simdata, pre_nodes, post_nodes, cs
+                        simdata, pre_nodes, post_nodes, cs, self.comm
                     )
                 )
             except Exception as e:
@@ -175,8 +174,8 @@ class NestAdapter(SimulatorAdapter):
             nest.rng_seed = simulation.seed
 
     def check_comm(self):
-        if nest.NumProcesses() != MPI.get_size():
+        if nest.NumProcesses() != self.comm.get_size():
             raise RuntimeError(
-                f"NEST is managing {nest.NumProcesses()} processes, but {MPI.get_size()}"
+                f"NEST is managing {nest.NumProcesses()} processes, but {self.comm.get_size()}"
                 " were detected. Please check your MPI setup."
             )

--- a/bsb_nest/connection.py
+++ b/bsb_nest/connection.py
@@ -4,7 +4,7 @@ import sys
 import nest
 import numpy as np
 import psutil
-from bsb import MPI, ConnectionModel, compose_nodes, config, types
+from bsb import ConnectionModel, compose_nodes, config, types
 from tqdm import tqdm
 
 from .distributions import nest_parameter
@@ -53,7 +53,7 @@ class NestConnection(compose_nodes(NestConnectionSettings, ConnectionModel)):
     tag = config.attr(type=str)
     synapse = config.attr(type=NestSynapseSettings, required=True)
 
-    def create_connections(self, simdata, pre_nodes, post_nodes, cs):
+    def create_connections(self, simdata, pre_nodes, post_nodes, cs, comm):
         import nest
 
         syn_spec = self.get_syn_spec()
@@ -64,11 +64,11 @@ class NestConnection(compose_nodes(NestConnectionSettings, ConnectionModel)):
         if self.rule is not None:
             nest.Connect(pre_nodes, post_nodes, self.get_conn_spec(), syn_spec)
         else:
-            MPI.barrier()
+            comm.barrier()
             for pre_locs, post_locs in self.predict_mem_iterator(
-                pre_nodes, post_nodes, cs
+                pre_nodes, post_nodes, cs, comm
             ):
-                MPI.barrier()
+                comm.barrier()
                 if len(pre_locs) == 0 or len(post_locs) == 0:
                     continue
                 cell_pairs, multiplicity = np.unique(
@@ -89,36 +89,36 @@ class NestConnection(compose_nodes(NestConnectionSettings, ConnectionModel)):
                     ssw,
                     return_synapsecollection=False,
                 )
-            MPI.barrier()
+            comm.barrier()
         return LazySynapseCollection(pre_nodes, post_nodes)
 
-    def predict_mem_iterator(self, pre_nodes, post_nodes, cs):
+    def predict_mem_iterator(self, pre_nodes, post_nodes, cs, comm):
         avmem = psutil.virtual_memory().available
         predicted_all_mem = (
             len(pre_nodes) * 8 * 2 + len(post_nodes) * 8 * 2 + len(cs) * 6 * 8 * (16 + 2)
-        ) * MPI.get_size()
+        ) * comm.get_size()
         n_chunks = len(cs.get_local_chunks("out"))
         predicted_local_mem = (predicted_all_mem / n_chunks) if n_chunks > 0 else 0.0
         if predicted_local_mem > avmem / 2:
             # Iterate block-by-block
-            return self.block_iterator(cs)
+            return self.block_iterator(cs, comm)
         elif predicted_all_mem > avmem / 2:
             # Iterate local hyperblocks
-            return self.local_iterator(cs)
+            return self.local_iterator(cs, comm)
         else:
             # Iterate all
             return (cs.load_connections().as_globals().all(),)
 
-    def block_iterator(self, cs):
+    def block_iterator(self, cs, comm):
         locals = cs.get_local_chunks("out")
 
         def block_iter():
             iter = locals
-            if MPI.get_rank() == 0:
+            if comm.get_rank() == 0:
                 iter = tqdm(iter, desc="hyperblocks", file=sys.stdout)
             for local in iter:
                 inner_iter = cs.load_connections().as_globals().from_(local)
-                if MPI.get_rank() == 0:
+                if comm.get_rank() == 0:
                     yield from tqdm(
                         inner_iter,
                         desc="blocks",
@@ -131,9 +131,9 @@ class NestConnection(compose_nodes(NestConnectionSettings, ConnectionModel)):
 
         return block_iter()
 
-    def local_iterator(self, cs):
+    def local_iterator(self, cs, comm):
         iter = cs.get_local_chunks("out")
-        if MPI.get_rank() == 0:
+        if comm.get_rank() == 0:
             iter = tqdm(iter, desc="hyperblocks", file=sys.stdout)
         yield from (
             cs.load_connections().as_globals().from_(local).all() for local in iter

--- a/bsb_nest/device.py
+++ b/bsb_nest/device.py
@@ -1,3 +1,4 @@
+import abc
 import typing
 import warnings
 
@@ -107,6 +108,22 @@ class NestDevice(DeviceModel):
     def register_device(self, simdata, device):
         simdata.devices[self] = device
         return device
+
+    @abc.abstractmethod
+    def implement(
+        self,
+        adapter: "NestAdapter",
+        simulation: "NestSimulation",
+        simdata: "SimulationData",
+    ):
+        """
+        Create, connect and register the Nest device.
+
+        :param bsb_nest.NestAdapter adapter:
+        :param bsb_nest.NestSimulation simulation: Nest simulation instance
+        :param bsb.SimulationData simdata: Simulation data instance
+        """
+        pass
 
 
 @config.node

--- a/bsb_nest/devices/poisson_generator.py
+++ b/bsb_nest/devices/poisson_generator.py
@@ -32,7 +32,7 @@ class PoissonGenerator(NestDevice, classmap_entry="poisson_generator"):
                 SpikeTrain(
                     sr.events["times"],
                     units="ms",
-                    senders=sr.events["senders"],
+                    array_annotations={"senders": sr.events["senders"]},
                     t_stop=simulation.duration,
                     device=self.name,
                     pop_size=len(nodes),

--- a/bsb_nest/devices/sinusoidal_poisson_generator.py
+++ b/bsb_nest/devices/sinusoidal_poisson_generator.py
@@ -53,7 +53,7 @@ class SinusoidalPoissonGenerator(
                 SpikeTrain(
                     sr.events["times"],
                     units="ms",
-                    senders=sr.events["senders"],
+                    array_annotations={"senders": sr.events["senders"]},
                     t_stop=simulation.duration,
                     device=self.name,
                     pop_size=len(nodes),

--- a/bsb_nest/devices/spike_recorder.py
+++ b/bsb_nest/devices/spike_recorder.py
@@ -20,7 +20,7 @@ class SpikeRecorder(NestDevice, classmap_entry="spike_recorder"):
                 SpikeTrain(
                     device.events["times"],
                     units="ms",
-                    senders=device.events["senders"],
+                    array_annotations={"senders": device.events["senders"]},
                     t_stop=simulation.duration,
                     device=self.name,
                     pop_size=len(nodes),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ dev = [
     "build~=1.0",
     "twine~=4.0",
     "pre-commit~=3.5",
-    "black~=24.1.1",
-    "isort~=5.12",
+    "black~=25.1.0",
+    "isort~=6.0.0",
     "snakeviz~=2.1",
     "bump-my-version~=0.24"
 ]

--- a/tests/test_nest.py
+++ b/tests/test_nest.py
@@ -241,7 +241,7 @@ class TestNest(
         netw.compile()
         results = netw.run_simulation("test")
         spike_times_bsb = results.spiketrains[0]
-        self.assertTrue(np.unique(spike_times_bsb.annotations["senders"]) == 1)
+        self.assertTrue(np.unique(spike_times_bsb.array_annotations["senders"]) == 1)
         membrane_potentials = results.analogsignals[0]
         # last time point is not recorded because of recorder delay.
         self.assertTrue(len(membrane_potentials) == duration / resolution - 1)


### PR DESCRIPTION
## What has been done?

- Bump isort and black to new versions
- Store spike senders in the array_annotations dictionary of neo.SpikeTrain to allow merging (see https://github.com/dbbs-lab/bsb-nest/issues/18)
- fix: forward MPI communicator to simulation adapter. (https://github.com/dbbs-lab/bsb-nest/pull/20)

Maybe it should be a be considered as a breaking change?